### PR TITLE
Fix failing test for alpine

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"testing"
-	"fmt"
 )
 
 func TestReadModelinesFileNotFound(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"testing"
+	"fmt"
 )
 
 func TestReadModelinesFileNotFound(t *testing.T) {

--- a/planner_test.go
+++ b/planner_test.go
@@ -9,15 +9,17 @@ import (
 
 func coreutils_bin() string {
 
+	var coreutils_bin string
+
 	switch os.Getenv("os") {
 	case "alpine":
-		coreutils_bin := "/bin"
+		coreutils_bin = "/bin"
 	case "debian":
-		coreutils_bin := "/bin"
+		coreutils_bin = "/bin"
 	case "ubuntu":
-		coreutils_bin := "/bin"
+		coreutils_bin = "/bin"
 	default:
-		coreutils_bin := "/usr/bin"
+		coreutils_bin = "/usr/bin"
 	}
 	return coreutils_bin
 }

--- a/planner_test.go
+++ b/planner_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"testing"
+	"fmt"
 )
 
 func coreutils_bin() string {

--- a/planner_test.go
+++ b/planner_test.go
@@ -3,8 +3,24 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
+
+func coreutils_bin() string {
+
+	switch os.Getenv("os") {
+	case "alpine":
+		coreutils_bin := "/bin"
+	case "debian":
+		coreutils_bin := "/bin"
+	case "ubuntu":
+		coreutils_bin := "/bin"
+	default:
+		coreutils_bin := "/usr/bin"
+	}
+	return coreutils_bin
+}
 
 func TestPkgsToInstall(t *testing.T) {
 	// Test with empty slice of PetsFiles
@@ -73,7 +89,7 @@ func TestChmod(t *testing.T) {
 	pa = Chmod(pf)
 
 	assertEquals(t, pa.Cause.String(), "CHMOD")
-	assertEquals(t, pa.Command.String(), "/usr/bin/chmod 0644 /dev/null")
+	assertEquals(t, pa.Command.String(), fmt.Sprintf("%s/chmod 0644 /dev/null", coreutils_bin()))
 
 	pf.Dest = "/etc/passwd"
 	pa = Chmod(pf)
@@ -109,5 +125,5 @@ func TestChown(t *testing.T) {
 	}
 
 	assertEquals(t, pa.Cause.String(), "OWNER")
-	assertEquals(t, pa.Command.String(), "/usr/bin/chown nobody:root /etc/passwd")
+	assertEquals(t, pa.Command.String(), fmt.Sprintf("%s/chown nobody:root /etc/passwd", coreutils_bin()))
 }

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -10,7 +10,6 @@ tasks:
     set -e
     if test $os = "debian"; then
       export PATH=/usr/local/go/bin:$PATH
-      export 
     fi
     go version
     cd source

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -11,6 +11,9 @@ tasks:
     if test $os = "debian"; then
       export PATH=/usr/local/go/bin:$PATH
     fi
+    if test $os = "alpine"; then
+      sudo apk add coreutils # TestPkgsToInstall implies that coreuitls are preinstalled 
+    fi
     go version
     cd source
     export os

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -10,9 +10,11 @@ tasks:
     set -e
     if test $os = "debian"; then
       export PATH=/usr/local/go/bin:$PATH
+      export 
     fi
     go version
     cd source
+    export os
     go test -v
   default: true
   depends:


### PR DESCRIPTION
Hi! This an attempt to fix fling tests for alpine. I made path to coreutls bin configurable that resolved some issues with chmod/chown , however one test still fails, please see - https://ci.sparrowhub.io/report/1781

```
18:32:23 :: === RUN   TestIsNotInstalled
18:32:23 :: 2022/11/15 18:32:23 [ERROR] running /sbin/apk info -qe astroid: 'exit status 1'
18:32:23 ::     util.go:79: true != false
18:32:23 :: --- FAIL: TestIsNotInstalled (0.06s)
```

And I don't now why, code of package.go should return false, but it seems it returns true:

https://github.com/melezhik/pets/blob/1bfa2969b1c536d29a3a8528ddd0aeec4d31ce9c/package.go#L135-L138

```go
	if family == APK {
		installed := NewCmd([]string{"apk", "info", "-qe", string(pp)})
		_, _, err := RunCmd(installed)
		if err != nil {
			log.Printf("[ERROR] running %s: '%s'\n", installed, err)
			return false
		}
		return true
	}
```