### PR TITLE
Package management optimisations

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,10 +46,9 @@ func main() {
 	log.SetOutput(GetLogFilter(debug))
 
 	// Print distro family
-	family := WhichPackageManager()
-	if family == APT {
+	if WhichPackageManager == APT {
 		log.Println("[DEBUG] Running on a Debian-like system")
-	} else if family == YUM {
+	} else if WhichPackageManager == YUM {
 		log.Println("[DEBUG] Running on a RedHat-like system")
 	}
 	// *** Config parser ***


### PR DESCRIPTION
Running `pets` when no changes needed to be done was taking ~20s, and it turns out `package=` validation was the culprit. These changes get it back down to a sweet 1.8s.

It's not unlikely that similar changes would be beneficial for package managers other than `pacman`, but I don't have such systems on hand to test.