### PR TITLE
Actually print global errors when they happen

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 	globalErrors := CheckGlobalConstraints(files)
 
 	if globalErrors != nil {
-		log.Println(err)
+		log.Println(globalErrors)
 		// Global validation errors mean we should stop the whole update.
 		return
 	}


### PR DESCRIPTION
This was accidentally printing `<nil>` as the error message